### PR TITLE
Fix overflowX on <pre> mapper

### DIFF
--- a/apps/public/src/components/Markdown/Markdown.jsx
+++ b/apps/public/src/components/Markdown/Markdown.jsx
@@ -48,7 +48,7 @@ const overrides = {
       variant: 'body1',
       component: 'pre',
       fontFamily: 'Monospace',
-      style: { marginLeft: '2em', marginBottom: '2em' }
+      style: { marginLeft: '2em', marginBottom: '2em', overflowX: 'auto' }
     }
   }
 };


### PR DESCRIPTION
Quick fix of the <pre> overflow on responsive site

Before:
![scrre](https://user-images.githubusercontent.com/7453394/90890037-818a4980-e3b9-11ea-8163-b88553a18543.png)


After:
![Profile-20200821T141652](https://user-images.githubusercontent.com/7453394/90889801-1476b400-e3b9-11ea-91e4-85e181f0c9ef.gif)
